### PR TITLE
Compare CI performance

### DIFF
--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -64,37 +64,37 @@ jobs:
       with:
         python-version: '3.12'
 
-    # - name: System tests dependencies
-    #   run: xargs -a system_test_requirements.txt sudo apt-get install
-    #   working-directory: test_suite
+    - name: System tests dependencies
+      run: xargs -a system_test_requirements.txt sudo apt-get install
+      working-directory: test_suite
 
-    # - name: Performance tests dependencies
-    #   run: pip install -r python_requirements.txt
-    #   working-directory: test_suite
+    - name: Performance tests dependencies
+      run: pip install -r python_requirements.txt
+      working-directory: test_suite
 
-    # - name: Run performance test with varying bitrate
-    #   id: system-test
-    #   run: ./system_tests.sh -p -L performance
-    #   working-directory: test_suite
-    #   continue-on-error: true
+    - name: Run performance test with varying bitrate
+      id: system-test
+      run: ./system_tests.sh -p -L performance
+      working-directory: test_suite
+      continue-on-error: true
 
-    # - name: Upload performance test graphs
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: performance-test-graphs
-    #     path: test_suite/system_test_logs/performance/*/*.png
+    - name: Upload performance test graphs
+      uses: actions/upload-artifact@v4
+      with:
+        name: performance-test-graphs
+        path: test_suite/system_test_logs/performance/*/*.png
 
-    # - name: Upload performance test data
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: performance-test-data
-    #     path: test_suite/system_test_logs/performance/*/performance_test_*_data.json
+    - name: Upload performance test data
+      uses: actions/upload-artifact@v4
+      with:
+        name: performance-test-data
+        path: test_suite/system_test_logs/performance/*/performance_test_*_data.json
 
-    # - name: Upload full performance test logs
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: performance-test-logs
-    #     path: test_suite/system_test_logs/
+    - name: Upload full performance test logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: performance-test-logs
+        path: test_suite/system_test_logs/
 
     - name: Fail job if performance test failed (for clarity in GitHub UI)
       if: ${{ steps.system-test.outcome == 'failure' }}

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -124,18 +124,11 @@ jobs:
       working-directory: test_suite
       run: unzip performance-test-data.zip -d previous_performance
 
-    - name: Debug directory contents
-      run: |
-        echo ROOT"
-        ls/
-        echo TEST SUITE"
-        ls test_suite/
-
     - name: Compare current and artifact performance
       id: performance-comparison
       working-directory: test_suite
       run: |
-        python compare_performance.py previous_performance/ performance/
+        python compare_performance.py previous_performance/ system_test_logs/performance/
         echo "exit-code=$?" >> $GITHUB_OUTPUT 
       continue-on-error: true
 

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Run performance test with varying bitrate
       id: system-test
-      run: ./system_tests.sh -p -L performance -c 0.5
+      run: ./system_tests.sh -p -L performance
       working-directory: test_suite
       continue-on-error: true
 

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -124,6 +124,13 @@ jobs:
       working-directory: test_suite
       run: unzip performance-test-data.zip -d previous_performance
 
+    - name: Debug directory contents
+      run: |
+        echo ROOT"
+        ls/
+        echo TEST SUITE"
+        ls test_suite/
+
     - name: Compare current and artifact performance
       id: performance-comparison
       working-directory: test_suite

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -10,44 +10,44 @@ on:
 
 jobs:
 
-  # SystemTests:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v4
+  SystemTests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
 
-  #   - name: Set up Go
-  #     uses: actions/setup-go@v5
-  #     with:
-  #       go-version-file: go.mod
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
 
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.12'
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
 
-  #   - name: System tests dependencies
-  #     run: xargs -a system_test_requirements.txt sudo apt-get install
-  #     working-directory: test_suite
+    - name: System tests dependencies
+      run: xargs -a system_test_requirements.txt sudo apt-get install
+      working-directory: test_suite
 
-  #   - name: Performance tests dependencies
-  #     run: pip install -r python_requirements.txt
-  #     working-directory: test_suite
+    - name: Performance tests dependencies
+      run: pip install -r python_requirements.txt
+      working-directory: test_suite
 
-  #   - name: Run system tests
-  #     id: system-test
-  #     run: ./system_tests.sh -c 0
-  #     working-directory: test_suite
-  #     continue-on-error: true
+    - name: Run system tests
+      id: system-test
+      run: ./system_tests.sh -c 0
+      working-directory: test_suite
+      continue-on-error: true
 
-  #   - name: Upload system test logs
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: system-test-logs
-  #       path: test_suite/system_test_logs/
+    - name: Upload system test logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: system-test-logs
+        path: test_suite/system_test_logs/
 
-  #   - name: Fail job if system test failed (for clarity in GitHub UI)
-  #     if: ${{ steps.system-test.outcome == 'failure' }}
-  #     run: exit 1
+    - name: Fail job if system test failed (for clarity in GitHub UI)
+      if: ${{ steps.system-test.outcome == 'failure' }}
+      run: exit 1
 
   PerformanceTests:
     runs-on: ubuntu-latest
@@ -130,29 +130,29 @@ jobs:
       run: python compare_performance.py previous_performance/ system_test_logs/performance/ > $GITHUB_STEP_SUMMARY
 
 
-  # IntegrationTests:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v4
+  IntegrationTests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
 
-  #   - name: Set up Go
-  #     uses: actions/setup-go@v5
-  #     with:
-  #       go-version-file: go.mod
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
 
-  #   - name: Run integration tests
-  #     id: integration-test
-  #     run: go test -coverpkg=./... -coverprofile cover.out -v ./...
+    - name: Run integration tests
+      id: integration-test
+      run: go test -coverpkg=./... -coverprofile cover.out -v ./...
 
-  #   - name: Create integration test coverage report
-  #     run: go tool cover -html cover.out -o cover.html
+    - name: Create integration test coverage report
+      run: go tool cover -html cover.out -o cover.html
 
-  #   - name: Upload integration test coverage report
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: integration-test-coverage
-  #       path: cover.html
+    - name: Upload integration test coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: integration-test-coverage
+        path: cover.html
 
-  #   - name: Fail job if integration test failed (for clarity in GitHub UI)
-  #     if: ${{ steps.integration-test.outcome == 'failure' }}
-  #     run: exit 1
+    - name: Fail job if integration test failed (for clarity in GitHub UI)
+      if: ${{ steps.integration-test.outcome == 'failure' }}
+      run: exit 1

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -109,6 +109,10 @@ jobs:
         path: ./test_suite
         skip_unpack: true
 
+    - name: Debug previous commit hash
+      if: ${{ github.event_name == 'push' }}
+      run: echo $${ github.event.before }
+
     - name: Download artifact from previous commit
       if: ${{ github.event_name == 'push' }}
       uses: dawidd6/action-download-artifact@v9

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -108,6 +108,7 @@ jobs:
         name: performance-test-data
         path: ./test_suite
         skip_unpack: true
+        workflow_conclusion: ""
 
     - name: Debug previous commit hash
       if: ${{ github.event_name == 'push' }}
@@ -121,6 +122,7 @@ jobs:
         name: performance-test-data
         path: ./test_suite
         skip_unpack: true
+        workflow_conclusion: ""
     
     - name: Unzip artifact
       working-directory: test_suite

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -110,10 +110,6 @@ jobs:
         skip_unpack: true
         workflow_conclusion: ""
 
-    - name: Debug previous commit hash
-      if: ${{ github.event_name == 'push' }}
-      run: echo ${{ github.event.before }}
-
     - name: Download artifact from previous commit
       if: ${{ github.event_name == 'push' }}
       uses: dawidd6/action-download-artifact@v9
@@ -127,9 +123,6 @@ jobs:
     - name: Unzip artifact
       working-directory: test_suite
       run: unzip performance-test-data.zip -d previous_performance
-    
-    - name: Check if artifact was successfully downloaded and extracted
-      run: ls test_suite/
 
     - name: Compare current and artifact performance
       id: performance-comparison

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -124,30 +124,11 @@ jobs:
       working-directory: test_suite
       run: unzip performance-test-data.zip -d previous_performance
 
-    - name: Compare current and artifact performance
+    - name: Compare current and artifact performance, and redirect results to job step summary
       id: performance-comparison
       working-directory: test_suite
-      run: |
-        python compare_performance.py previous_performance/ system_test_logs/performance/
-        echo "exit-code=$?" >> $GITHUB_OUTPUT 
-      continue-on-error: true
+      run: python compare_performance.py previous_performance/ system_test_logs/performance/ >> $GITHUB_OUTPUT
 
-    - name: Report result of comparison in GitHub job summary
-      run: |
-        echo ${{ steps.performance-comparison.outputs.exit-code }}
-        if [[ ${{ steps.performance-comparison.outputs.exit-code }} -eq 0 ]]; then 
-          echo "### ✅ No significant performance change" >> $GITHUB_STEP_SUMMARY
-          exit 0
-        elif [[ ${{ steps.performance-comparison.outputs.exit-code }} -eq 2 ]]; then
-          echo "### 📉 Performance has become worse :(" >> $GITHUB_STEP_SUMMARY
-          exit 0
-        elif [[ ${{ steps.performance-comparison.outputs.exit-code }} -eq 3 ]]; then
-          echo "### 📈 Performance has improved!" >> $GITHUB_STEP_SUMMARY
-          exit 1
-        else
-          echo "### ❌ Unable to compare performance, see the output of the 'Compare current and artifact performance' step for details" >> $GITHUB_STEP_SUMMARY
-          exit 1
-        fi
 
   # IntegrationTests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Run performance test with varying bitrate
       id: system-test
-      run: ./system_tests.sh -p -L performance -c 0.5
+      run: ./system_tests.sh -p -L performance -c 1
       working-directory: test_suite
       continue-on-error: true
 
@@ -135,19 +135,19 @@ jobs:
     - name: Report result of comparison in GitHub job summary
       run: |
         case ${{ steps.performance-comparison.outputs.exit-code }} in
-          0)
+          "0")
             echo "### ✅ No significant performance change" >> $GITHUB_STEP_SUMMARY
             exit 0
             ;;
-          1)
+          "1")
             echo "### ❌ Unable to compare performance, see the output of the 'Compare current and artifact performance' step for details" >> $GITHUB_STEP_SUMMARY
             exit 1
             ;;
-          2)
+          "2")
             echo "### 📉 Performance has become worse :(" >> $GITHUB_STEP_SUMMARY
             exit 0
             ;;
-          3)
+          "3")
             echo "### 📈 Performance has improved!" >> $GITHUB_STEP_SUMMARY
             exit 1
             ;;

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Run performance test with varying bitrate
       id: system-test
-      run: ./system_tests.sh -p -L performance
+      run: ./system_tests.sh -p -L performance -c 0.5
       working-directory: test_suite
       continue-on-error: true
 

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -111,13 +111,13 @@ jobs:
 
     - name: Debug previous commit hash
       if: ${{ github.event_name == 'push' }}
-      run: echo $${ github.event.before }
+      run: echo ${ github.event.before }
 
     - name: Download artifact from previous commit
       if: ${{ github.event_name == 'push' }}
       uses: dawidd6/action-download-artifact@v9
       with: 
-        commit: $${ github.event.before }
+        commit: ${ github.event.before }
         name: performance-test-data
         path: ./test_suite
         skip_unpack: true

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -114,9 +114,7 @@ jobs:
       continue-on-error: true
     
     - name: Check if artifact was successfully downloaded and extracted
-      run: 
-        - ls test_suite/
-        - ls
+      run: ls; ls test_suite/
 
   # IntegrationTests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -102,10 +102,10 @@ jobs:
 
     - name: Download artifact from previous commit
       uses: dawidd6/action-download-artifact@v9
-      working-directory: test_suite
       with: 
         commit: 3379e5ff95c38276268f65791cab7754062b2298
         name: performance-test-data
+        path: ./test_suite
         skip_unpack: true
     
     - name: Unzip artifact

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -102,12 +102,18 @@ jobs:
 
     - name: Download artifact from previous commit
       uses: dawidd6/action-download-artifact@v9
+      working-directory: test_suite
       with: 
-        commit: d714530587846aa184cec41049b90ec3c023cd11
-        name: performance-test-data-d714530587846aa184cec41049b90ec3c023cd11
-
-    - name: Check if artifact was successfully downloaded
-      run: ls
+        commit: 3379e5ff95c38276268f65791cab7754062b2298
+        name: performance-test-data
+        skip_unpack: true
+    
+    - name: Unzip artifact
+      working-directory: test_suite
+      run: unzip performance_test_data.zip -d previous_performance
+    
+    - name: Check if artifact was successfully downloaded and extracted
+      run: ls test_suite/
 
   # IntegrationTests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -110,11 +110,10 @@ jobs:
     
     - name: Unzip artifact
       working-directory: test_suite
-      run: unzip performance_test_data.zip -d previous_performance
-      continue-on-error: true
+      run: unzip performance-test-data.zip -d previous_performance
     
     - name: Check if artifact was successfully downloaded and extracted
-      run: ls; ls test_suite/
+      run: ls test_suite/
 
   # IntegrationTests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -134,16 +134,14 @@ jobs:
 
     - name: Report result of comparison in GitHub job summary
       run: |
-        exit_code=${{ steps.performance-comparison.outputs.exit-code }}
-        echo $exit_code
         echo ${{ steps.performance-comparison.outputs.exit-code }}
-        if [[ $exit_code -eq 0 ]]; then 
+        if [[ ${{ steps.performance-comparison.outputs.exit-code }} -eq 0 ]]; then 
           echo "### ✅ No significant performance change" >> $GITHUB_STEP_SUMMARY
           exit 0
-        elif [[ $exit_code -eq 2 ]]; then
+        elif [[ ${{ steps.performance-comparison.outputs.exit-code }} -eq 2 ]]; then
           echo "### 📉 Performance has become worse :(" >> $GITHUB_STEP_SUMMARY
           exit 0
-        elif [[ $exit_code -eq 3 ]]; then
+        elif [[ ${{ steps.performance-comparison.outputs.exit-code }} -eq 3 ]]; then
           echo "### 📈 Performance has improved!" >> $GITHUB_STEP_SUMMARY
           exit 1
         else

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Compare current and artifact performance, and redirect results to job step summary
       id: performance-comparison
       working-directory: test_suite
-      run: python compare_performance.py previous_performance/ system_test_logs/performance/ >> $GITHUB_OUTPUT
+      run: python compare_performance.py previous_performance/ system_test_logs/performance/ > $GITHUB_STEP_SUMMARY
 
 
   # IntegrationTests:

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -127,16 +127,18 @@ jobs:
     - name: Stop job and give warning if downloading previous artifact failed 
       if: ${{ steps.download_target_branch.outcome == 'failure' || steps.download_previous_commit.outcome == 'failure' }}
       run: |
-        echo "# ⚠️ Could not make performance comparison: downloading performance test data of target branch head/previous commit failed. See the corresponding PerformanceTests job step for details" >> $GITHUB_STEP_SUMMARY
-        exit 0
+        echo "# ⚠️ Could not make performance comparison" >> $GITHUB_STEP_SUMMARY
+        echo "Downloading performance test data of target branch head/previous commit failed. See the corresponding PerformanceTests job step for details" >> $GITHUB_STEP_SUMMARY
 
     - name: Unzip artifact
       working-directory: test_suite
+      if: ${{ steps.download_target_branch.outcome == 'success' || steps.download_previous_commit.outcome == 'success' }}
       run: unzip performance-test-data.zip -d previous_performance
 
     - name: Compare current and artifact performance, and redirect results to job step summary
       id: performance-comparison
       working-directory: test_suite
+      if: ${{ steps.download_target_branch.outcome == 'success' || steps.download_previous_commit.outcome == 'success' }}
       run: python compare_performance.py previous_performance/ system_test_logs/performance/ > $GITHUB_STEP_SUMMARY
 
 

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -132,8 +132,33 @@ jobs:
       run: ls test_suite/
 
     - name: Compare current and artifact performance
+      id: performance-comparison
       working-directory: test_suite
-      run: python compare_performance.py previous_performance/ performance/
+      run: |
+        python compare_performance.py previous_performance/ performance/
+        echo "exit-code=$?" >> $GITHUB_OUTPUT 
+      continue-on-error: true
+
+    - name: Report result of comparison in GitHub job summary
+      run: |
+        case ${{ steps.performance-comparison.outputs.exit-code }} in
+          0)
+            echo "### ✅ No significant performance change" >> $GITHUB_STEP_SUMMARY
+            exit 0
+            ;;
+          1)
+            echo "### ❌ Unable to compare performance, see the output of the 'Compare current and artifact performance' step for details" >> $GITHUB_STEP_SUMMARY
+            exit 1
+            ;;
+          2)
+            echo "### 📉 Performance has become worse :(" >> $GITHUB_STEP_SUMMARY
+            exit 0
+            ;;
+          3)
+            echo "### 📈 Performance has improved!" >> $GITHUB_STEP_SUMMARY
+            exit 1
+            ;;
+        esac
 
   # IntegrationTests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -10,44 +10,44 @@ on:
 
 jobs:
 
-  SystemTests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
+  # SystemTests:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
+  #   - name: Set up Go
+  #     uses: actions/setup-go@v5
+  #     with:
+  #       go-version-file: go.mod
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: '3.12'
 
-    - name: System tests dependencies
-      run: xargs -a system_test_requirements.txt sudo apt-get install
-      working-directory: test_suite
+  #   - name: System tests dependencies
+  #     run: xargs -a system_test_requirements.txt sudo apt-get install
+  #     working-directory: test_suite
 
-    - name: Performance tests dependencies
-      run: pip install -r python_requirements.txt
-      working-directory: test_suite
+  #   - name: Performance tests dependencies
+  #     run: pip install -r python_requirements.txt
+  #     working-directory: test_suite
 
-    - name: Run system tests
-      id: system-test
-      run: ./system_tests.sh -c 0
-      working-directory: test_suite
-      continue-on-error: true
+  #   - name: Run system tests
+  #     id: system-test
+  #     run: ./system_tests.sh -c 0
+  #     working-directory: test_suite
+  #     continue-on-error: true
 
-    - name: Upload system test logs
-      uses: actions/upload-artifact@v4
-      with:
-        name: system-test-logs
-        path: test_suite/system_test_logs/
+  #   - name: Upload system test logs
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: system-test-logs
+  #       path: test_suite/system_test_logs/
 
-    - name: Fail job if system test failed (for clarity in GitHub UI)
-      if: ${{ steps.system-test.outcome == 'failure' }}
-      run: exit 1
+  #   - name: Fail job if system test failed (for clarity in GitHub UI)
+  #     if: ${{ steps.system-test.outcome == 'failure' }}
+  #     run: exit 1
 
   PerformanceTests:
     runs-on: ubuntu-latest
@@ -87,7 +87,7 @@ jobs:
     - name: Upload performance test data
       uses: actions/upload-artifact@v4
       with:
-        name: performance-test-data-${{ github.sha }}
+        name: performance-test-data
         path: test_suite/system_test_logs/performance/*/performance_test_*_data.json
 
     - name: Upload full performance test logs
@@ -100,29 +100,38 @@ jobs:
       if: ${{ steps.system-test.outcome == 'failure' }}
       run: exit 1
 
-  IntegrationTests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
+    - name: Download artifact from previous commit
+      uses: dawidd6/action-download-artifact@v9
+      with: 
+        commit: d714530587846aa184cec41049b90ec3c023cd11
+        name: performance-test-data-d714530587846aa184cec41049b90ec3c023cd11
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
+    - name: Check if artifact was successfully downloaded
+      run: ls
 
-    - name: Run integration tests
-      id: integration-test
-      run: go test -coverpkg=./... -coverprofile cover.out -v ./...
+  # IntegrationTests:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v4
 
-    - name: Create integration test coverage report
-      run: go tool cover -html cover.out -o cover.html
+  #   - name: Set up Go
+  #     uses: actions/setup-go@v5
+  #     with:
+  #       go-version-file: go.mod
 
-    - name: Upload integration test coverage report
-      uses: actions/upload-artifact@v4
-      with:
-        name: integration-test-coverage
-        path: cover.html
+  #   - name: Run integration tests
+  #     id: integration-test
+  #     run: go test -coverpkg=./... -coverprofile cover.out -v ./...
 
-    - name: Fail job if integration test failed (for clarity in GitHub UI)
-      if: ${{ steps.integration-test.outcome == 'failure' }}
-      run: exit 1
+  #   - name: Create integration test coverage report
+  #     run: go tool cover -html cover.out -o cover.html
+
+  #   - name: Upload integration test coverage report
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: integration-test-coverage
+  #       path: cover.html
+
+  #   - name: Fail job if integration test failed (for clarity in GitHub UI)
+  #     if: ${{ steps.integration-test.outcome == 'failure' }}
+  #     run: exit 1

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -88,7 +88,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: performance-test-data
-        path: test_suite/system_test_logs/performance/*/performance_test_*_data.json
+        path: test_suite/system_test_logs/performance/*/performance_test_data.json
 
     - name: Upload full performance test logs
       uses: actions/upload-artifact@v4
@@ -100,10 +100,20 @@ jobs:
       if: ${{ steps.system-test.outcome == 'failure' }}
       run: exit 1
 
-    - name: Download artifact from previous commit
+    - name: Download artifact from target branch head
+      if: ${{ github.event_name == 'pull_request' }}
       uses: dawidd6/action-download-artifact@v9
       with: 
-        commit: 3379e5ff95c38276268f65791cab7754062b2298
+        branch: ${{ github.base_ref }}
+        name: performance-test-data
+        path: ./test_suite
+        skip_unpack: true
+
+    - name: Download artifact from previous commit
+      if: ${{ github.event_name == 'push' }}
+      uses: dawidd6/action-download-artifact@v9
+      with: 
+        commit: $${ github.event.before }
         name: performance-test-data
         path: ./test_suite
         skip_unpack: true
@@ -114,6 +124,10 @@ jobs:
     
     - name: Check if artifact was successfully downloaded and extracted
       run: ls test_suite/
+
+    - name: Compare current and artifact performance
+      working-directory: test_suite
+      run: python compare_performance.py previous_performance/ performance/
 
   # IntegrationTests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Run performance test with varying bitrate
       id: system-test
-      run: ./system_tests.sh -p -L performance -c 1
+      run: ./system_tests.sh -p -L performance
       working-directory: test_suite
       continue-on-error: true
 

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -111,13 +111,13 @@ jobs:
 
     - name: Debug previous commit hash
       if: ${{ github.event_name == 'push' }}
-      run: echo ${ github.event.before }
+      run: echo ${{ github.event.before }}
 
     - name: Download artifact from previous commit
       if: ${{ github.event_name == 'push' }}
       uses: dawidd6/action-download-artifact@v9
       with: 
-        commit: ${ github.event.before }
+        commit: ${{ github.event.before }}
         name: performance-test-data
         path: ./test_suite
         skip_unpack: true

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -135,13 +135,13 @@ jobs:
     - name: Report result of comparison in GitHub job summary
       run: |
         exit_code=${{ steps.performance-comparison.outputs.exit-code }}
-        if [[ $exit_code -eq 0]]; then 
+        if [[ $exit_code -eq 0 ]]; then 
           echo "### ✅ No significant performance change" >> $GITHUB_STEP_SUMMARY
           exit 0
-        elif [[ $exit_code -eq 2]]; then
+        elif [[ $exit_code -eq 2 ]]; then
           echo "### 📉 Performance has become worse :(" >> $GITHUB_STEP_SUMMARY
           exit 0
-        elif [[ $exit_code -eq 3]]; then
+        elif [[ $exit_code -eq 3 ]]; then
           echo "### 📈 Performance has improved!" >> $GITHUB_STEP_SUMMARY
           exit 1
         else

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -101,6 +101,7 @@ jobs:
       run: exit 1
 
     - name: Download artifact from target branch head
+      id: download_target_branch
       if: ${{ github.event_name == 'pull_request' }}
       uses: dawidd6/action-download-artifact@v9
       with: 
@@ -109,8 +110,10 @@ jobs:
         path: ./test_suite
         skip_unpack: true
         workflow_conclusion: ""
+      continue-on-error: true
 
     - name: Download artifact from previous commit
+      id: download_previous_commit
       if: ${{ github.event_name == 'push' }}
       uses: dawidd6/action-download-artifact@v9
       with: 
@@ -119,7 +122,14 @@ jobs:
         path: ./test_suite
         skip_unpack: true
         workflow_conclusion: ""
+      continue-on-error: true
     
+    - name: Stop job and give warning if downloading previous artifact failed 
+      if: ${{ steps.download_target_branch.outcome == 'failure' || steps.download_previous_commit.outcome == 'failure' }}
+      run: |
+        echo "# ⚠️ Could not make performance comparison: downloading performance test data of target branch head/previous commit failed. See the corresponding PerformanceTests job step for details" >> $GITHUB_STEP_SUMMARY
+        exit 0
+
     - name: Unzip artifact
       working-directory: test_suite
       run: unzip performance-test-data.zip -d previous_performance

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -134,24 +134,20 @@ jobs:
 
     - name: Report result of comparison in GitHub job summary
       run: |
-        case ${{ steps.performance-comparison.outputs.exit-code }} in
-          "0")
-            echo "### ✅ No significant performance change" >> $GITHUB_STEP_SUMMARY
-            exit 0
-            ;;
-          "1")
-            echo "### ❌ Unable to compare performance, see the output of the 'Compare current and artifact performance' step for details" >> $GITHUB_STEP_SUMMARY
-            exit 1
-            ;;
-          "2")
-            echo "### 📉 Performance has become worse :(" >> $GITHUB_STEP_SUMMARY
-            exit 0
-            ;;
-          "3")
-            echo "### 📈 Performance has improved!" >> $GITHUB_STEP_SUMMARY
-            exit 1
-            ;;
-        esac
+        exit_code=${{ steps.performance-comparison.outputs.exit-code }}
+        if [[ $exit_code -eq 0]]; then 
+          echo "### ✅ No significant performance change" >> $GITHUB_STEP_SUMMARY
+          exit 0
+        elif [[ $exit_code -eq 2]]; then
+          echo "### 📉 Performance has become worse :(" >> $GITHUB_STEP_SUMMARY
+          exit 0
+        elif [[ $exit_code -eq 3]]; then
+          echo "### 📈 Performance has improved!" >> $GITHUB_STEP_SUMMARY
+          exit 1
+        else
+          echo "### ❌ Unable to compare performance, see the output of the 'Compare current and artifact performance' step for details" >> $GITHUB_STEP_SUMMARY
+          exit 1
+        fi
 
   # IntegrationTests:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -82,7 +82,13 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: performance-test-graphs
-        path: test_suite/system_test_logs/performance/1_No-NAT_No-NAT/*.png
+        path: test_suite/system_test_logs/performance/*/*.png
+
+    - name: Upload performance test data
+      uses: actions/upload-artifact@v4
+      with:
+        name: performance-test-data-${{ github.sha }}
+        path: test_suite/system_test_logs/performance/*/performance_test_*_data.json
 
     - name: Upload full performance test logs
       uses: actions/upload-artifact@v4

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -135,6 +135,8 @@ jobs:
     - name: Report result of comparison in GitHub job summary
       run: |
         exit_code=${{ steps.performance-comparison.outputs.exit-code }}
+        echo $exit_code
+        echo ${{ steps.performance-comparison.outputs.exit-code }}
         if [[ $exit_code -eq 0 ]]; then 
           echo "### ✅ No significant performance change" >> $GITHUB_STEP_SUMMARY
           exit 0

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -64,37 +64,37 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: System tests dependencies
-      run: xargs -a system_test_requirements.txt sudo apt-get install
-      working-directory: test_suite
+    # - name: System tests dependencies
+    #   run: xargs -a system_test_requirements.txt sudo apt-get install
+    #   working-directory: test_suite
 
-    - name: Performance tests dependencies
-      run: pip install -r python_requirements.txt
-      working-directory: test_suite
+    # - name: Performance tests dependencies
+    #   run: pip install -r python_requirements.txt
+    #   working-directory: test_suite
 
-    - name: Run performance test with varying bitrate
-      id: system-test
-      run: ./system_tests.sh -p -L performance
-      working-directory: test_suite
-      continue-on-error: true
+    # - name: Run performance test with varying bitrate
+    #   id: system-test
+    #   run: ./system_tests.sh -p -L performance
+    #   working-directory: test_suite
+    #   continue-on-error: true
 
-    - name: Upload performance test graphs
-      uses: actions/upload-artifact@v4
-      with:
-        name: performance-test-graphs
-        path: test_suite/system_test_logs/performance/*/*.png
+    # - name: Upload performance test graphs
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: performance-test-graphs
+    #     path: test_suite/system_test_logs/performance/*/*.png
 
-    - name: Upload performance test data
-      uses: actions/upload-artifact@v4
-      with:
-        name: performance-test-data
-        path: test_suite/system_test_logs/performance/*/performance_test_*_data.json
+    # - name: Upload performance test data
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: performance-test-data
+    #     path: test_suite/system_test_logs/performance/*/performance_test_*_data.json
 
-    - name: Upload full performance test logs
-      uses: actions/upload-artifact@v4
-      with:
-        name: performance-test-logs
-        path: test_suite/system_test_logs/
+    # - name: Upload full performance test logs
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: performance-test-logs
+    #     path: test_suite/system_test_logs/
 
     - name: Fail job if performance test failed (for clarity in GitHub UI)
       if: ${{ steps.system-test.outcome == 'failure' }}
@@ -111,9 +111,12 @@ jobs:
     - name: Unzip artifact
       working-directory: test_suite
       run: unzip performance_test_data.zip -d previous_performance
+      continue-on-error: true
     
     - name: Check if artifact was successfully downloaded and extracted
-      run: ls test_suite/
+      run: 
+        - ls test_suite/
+        - ls
 
   # IntegrationTests:
   #   runs-on: ubuntu-latest

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -24,7 +24,7 @@ new=sys.argv[2]
 COMPARISON_CONFIG = {
     "Target bitrate": { 
         "packet_loss": {
-            "worse": lambda new, baseline: new > 1.1 * baseline and new > baseline + 1, # Second condition for edge case baseline = 0
+            "worse": lambda new, baseline: new > 1.1 * baseline and new > baseline + 0.1, # Second condition for edge case baseline = 0
             "better": lambda new, baseline: new < 0.9 * baseline
         }
     }

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -84,7 +84,7 @@ def compare_measurements(new_data: dict, baseline_data: dict):
         
         for i, (new_val, baseline_val) in enumerate(zip(new_values, baseline_values)):
             if is_worse(new_val, baseline_val):
-                report_performance_change(True, metric_label, i, baseline_val, new_val)
+                report_performance_change(False, metric_label, i, baseline_val, new_val)
                 performance_worse = True
 
             if is_better(new_val, baseline_val):

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -27,9 +27,9 @@ COMPARISON_CONFIG = {
     "Target bitrate": { 
         "packet_loss": {
             # Second condition to prevent performance being considered better when new = 0 and baseline is very small
-            "better": lambda new, baseline: new < 0.9 * baseline and new < baseline - 1,
+            "better": lambda new, baseline: new < 0.8 * baseline and new < baseline - 2,
             # Second condition to prevent performance being considered worse when baseline = 0 and new is very small
-            "worse": lambda new, baseline: new > 1.1 * baseline or (baseline == 0 and new > baseline + 1)
+            "worse": lambda new, baseline: new > 1.2 * baseline or (baseline == 0 and new > baseline + 2)
         }
     }
 }

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -26,10 +26,8 @@ new=sys.argv[2]
 COMPARISON_CONFIG = {
     "Target bitrate": { 
         "packet_loss": {
-            # Second condition to prevent performance being considered better when new = 0 and baseline is very small
-            "better": lambda new, baseline: new < 0.8 * baseline and new < baseline - 2,
-            # Second condition to prevent performance being considered worse when baseline = 0 and new is very small
-            "worse": lambda new, baseline: new > 1.2 * baseline or (baseline == 0 and new > baseline + 2)
+            "better": lambda new, baseline: new < 0.8 * baseline and new < baseline - 5,
+            "worse": lambda new, baseline: new > 1.2 * baseline and new > baseline + 5
         }
     }
 }

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -58,12 +58,13 @@ def check_same_performance_test(new_data: dict, baseline_data: dict, rel_path: s
     if not all_required_metrics:
         failure(f"for {rel_path}, some of the measurements in the baseline data are not present in the new data")
 
-def report_performance_change(better: bool, metric: str, idx: int, baseline: float, new: float):
+def report_performance_change(better: bool, metric: str, idx: int, test_var: str, test_var_values: list[float], baseline: float, new: float):
     change = "improved" if better else "degraded"
-    print(f"- {metric} {change} at index {idx}: {baseline:.1f} -> {new:.1f}")
+    print(f"- For {test_var} = {test_var_values[idx]}, {metric} {change}: {baseline:.1f} -> {new:.1f}")
     
 def compare_measurements(new_data: dict, baseline_data: dict):
     test_var = baseline_data["test_var"]["label"] 
+    test_var_values = baseline_data["test_var"]["values"]
 
     if not(test_var in COMPARISON_CONFIG.keys()):
         return
@@ -84,14 +85,12 @@ def compare_measurements(new_data: dict, baseline_data: dict):
         
         for i, (new_val, baseline_val) in enumerate(zip(new_values, baseline_values)):
             if is_worse(new_val, baseline_val):
-                report_performance_change(False, metric_label, i, baseline_val, new_val)
+                report_performance_change(False, metric_label, i, test_var, test_var_values, baseline_val, new_val)
                 performance_worse = True
 
             if is_better(new_val, baseline_val):
-                report_performance_change(True, metric_label, i, baseline_val, new_val)
+                report_performance_change(True, metric_label, i, test_var, test_var_values, baseline_val, new_val)
                 performance_better = True and not performance_worse # Worse performance has higher priority than better performance
-
-        
 
 # Iterate over all data files from baseline performance test data
 cwd = os.getcwd()

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -6,8 +6,8 @@ from pathlib import Path
 # Exit codes
 EXIT_PERFORMANCE_SIMILAR = 0
 EXIT_COMPARISON_FAILED = 1
-EXIT_PERFORMANCE_WORSE = 2
-EXIT_PERFORMANCE_BETTER = 3
+EXIT_PERFORMANCE_WORSE = 1
+EXIT_PERFORMANCE_BETTER = 0
 
 # Ensure both parameters are provided
 if len(sys.argv) - 1 != 2:
@@ -24,9 +24,10 @@ new=sys.argv[2]
 COMPARISON_CONFIG = {
     "Target bitrate": { 
         "packet_loss": {
-            "better": lambda new, baseline: new < 0.9 * baseline,
+            # Second condition to prevent performance being considered better when new = 0 and baseline is very small
+            "better": lambda new, baseline: new < 0.9 * baseline and new < baseline - 1,
             # Second condition to prevent performance being considered worse when baseline = 0 and new is very small
-            "worse": lambda new, baseline: new > 1.1 * baseline or (baseline == 0 and new > baseline + 0.01)
+            "worse": lambda new, baseline: new > 1.1 * baseline or (baseline == 0 and new > baseline + 1)
         }
     }
 }

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -20,11 +20,11 @@ The two parameters should be either system test logs containing only performance
 baseline=sys.argv[1]
 new=sys.argv[2]
 
-# This dictionary defines which measurements to compare, and when to consider two measurements worse/better/better_factor
+# This dictionary defines which measurements to compare, and when to consider two measurements worse/better/similar
 COMPARISON_CONFIG = {
     "Target bitrate": { 
         "packet_loss": {
-            "worse": lambda new, baseline: new > 1.1 * baseline,
+            "worse": lambda new, baseline: new > 1.1 * baseline and new > baseline + 1, # Second condition for edge case baseline = 0
             "better": lambda new, baseline: new < 0.9 * baseline
         }
     }

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -26,7 +26,7 @@ COMPARISON_CONFIG = {
         "packet_loss": {
             "better": lambda new, baseline: new < 0.9 * baseline,
             # Second condition to prevent performance being considered worse when baseline = 0 and new is very small
-            "worse": lambda new, baseline: new > 1.1 * baseline or (baseline == 0 and new > baseline + 0.1)
+            "worse": lambda new, baseline: new > 1.1 * baseline or (baseline == 0 and new > baseline + 0.01)
         }
     }
 }
@@ -76,25 +76,26 @@ def compare_measurements(new_data: dict, baseline_data: dict, rel_path: str):
         for i, (new_val, baseline_val) in enumerate(zip(new_values, baseline_values)):
             if is_worse(new_val, baseline_val):
                 performance_worse = True
-                print(f"\tPerformance decrease for {rel_path}, metric {metric}, value at index {i}")
+                print(f"\t\tPerformance decrease for {rel_path}, metric {metric}, index {i}: {baseline_val:.1f} -> {new_val:.1f}")
 
             if is_better(new_val, baseline_val):
                 performance_better = True and not performance_worse # Worse performance has higher priority than better performance
-                print(f"\tPerformance increase for {rel_path}, metric {metric}, value at index {i}")
+                print(f"\t\tPerformance increase for {rel_path}, metric {metric}, index {i}: {baseline_val:.1f} -> {new_val:.1f}")
 
         
 
 # Iterate over all data files from baseline performance test data
 print(f"Comparing performance of all tests present in baseline data...")
 cwd = os.getcwd()
-baseline_files = Path(f"{cwd}/{baseline}").rglob("performance_test_*_data.json*")
+baseline_files = Path(f"{cwd}/{baseline}").rglob("performance_test_data.json*")
 
 for path in baseline_files:
     path = str(path)
 
     # Get relative path by removing current working directory + baseline directory prefix
     rel_path = path[len(cwd) + len(baseline) + 1:]
-    
+    print(f"\tComparing performance of {rel_path}...")
+
     # Attempt to open same performance test file in new data
     try:
         with open(f"{cwd}/{new}/{rel_path}") as f_new:

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -24,8 +24,9 @@ new=sys.argv[2]
 COMPARISON_CONFIG = {
     "Target bitrate": { 
         "packet_loss": {
-            "worse": lambda new, baseline: new > 1.1 * baseline and new > baseline + 0.1, # Second condition for edge case baseline = 0
-            "better": lambda new, baseline: new < 0.9 * baseline
+            "better": lambda new, baseline: new < 0.9 * baseline,
+            # Second condition to prevent performance being considered worse when baseline = 0 and new is very small
+            "worse": lambda new, baseline: new > 1.1 * baseline or (baseline == 0 and new > baseline + 1)
         }
     }
 }

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -1,0 +1,120 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+# Exit codes
+EXIT_PERFORMANCE_SIMILAR = 0
+EXIT_COMPARISON_FAILED = 1
+EXIT_PERFORMANCE_WORSE = 2
+EXIT_PERFORMANCE_BETTER = 3
+
+# Ensure both parameters are provided
+if len(sys.argv) - 1 != 2:
+    print(f"""
+Usage: python {sys.argv[0]} <BASELINE PERFORMANCE TEST DATA> <NEW PERFORMANCE TEST DATA>
+
+The two parameters should be either system test logs containing only performance tests, or extracted performance-test-data artifacts from GitHub Actions""")
+    exit(EXIT_COMPARISON_FAILED)
+
+baseline=sys.argv[1]
+new=sys.argv[2]
+
+# This dictionary defines which measurements to compare, and when to consider two measurements worse/better/better_factor
+COMPARISON_CONFIG = {
+    "Target bitrate": { 
+        "packet_loss": {
+            "worse": lambda new, baseline: new > 1.1 * baseline,
+            "better": lambda new, baseline: new < 0.9 * baseline
+        }
+    }
+}
+
+# Keep track of whether performance is worse or better
+performance_worse = False
+performance_better = False
+
+def failure(reason: str):
+    print(f"Comparison failed: {reason}")
+    exit(EXIT_COMPARISON_FAILED)
+
+def check_same_performance_test(new_data: dict, baseline_data: dict, rel_path: str):
+    """Check whether the two data files contain the same performance test, otherwise comparison is not possible"""
+
+    same_test_var = new_data["test_var"] == baseline_data["test_var"]
+
+    if not same_test_var:
+        failure(f"mismatch in test variable or its values for {rel_path}")
+
+    baseline_metrics = set(baseline_data["measurements"].keys())
+    new_metrics = set(new_data["measurements"].keys())
+    all_required_metrics = baseline_metrics <= new_metrics
+
+    if not all_required_metrics:
+        failure(f"for {rel_path}, some of the measurements in the baseline data are not present in the new data")
+
+def compare_measurements(new_data: dict, baseline_data: dict, rel_path: str):
+    test_var = baseline_data["test_var"]["label"] 
+
+    if not(test_var in COMPARISON_CONFIG.keys()):
+        return
+    
+    # Keep track of performance difference by modifying the global variables
+    global performance_worse, performance_better
+    
+    metrics_to_compare = COMPARISON_CONFIG[test_var].keys()
+    new_measurements = new_data["measurements"]
+    baseline_measurements = baseline_data["measurements"]
+
+    for metric in metrics_to_compare:
+        new_values = new_measurements[metric]["values"]["average"]["eduP2P"]
+        baseline_values = baseline_measurements[metric]["values"]["average"]["eduP2P"]
+        is_worse = COMPARISON_CONFIG[test_var][metric]["worse"]
+        is_better = COMPARISON_CONFIG[test_var][metric]["better"]
+        
+        for i, (new_val, baseline_val) in enumerate(zip(new_values, baseline_values)):
+            if is_worse(new_val, baseline_val):
+                performance_worse = True
+                print(f"\tPerformance decrease for {rel_path}, metric {metric}, value at index {i}")
+
+            if is_better(new_val, baseline_val):
+                performance_better = True and not performance_worse # Worse performance has higher priority than better performance
+                print(f"\tPerformance increase for {rel_path}, metric {metric}, value at index {i}")
+
+        
+
+# Iterate over all data files from baseline performance test data
+print(f"Comparing performance of all tests present in baseline data...")
+cwd = os.getcwd()
+baseline_files = Path(f"{cwd}/{baseline}").rglob("performance_test_*_data.json*")
+
+for path in baseline_files:
+    path = str(path)
+
+    # Get relative path by removing current working directory + baseline directory prefix
+    rel_path = path[len(cwd) + len(baseline) + 1:]
+    
+    # Attempt to open same performance test file in new data
+    try:
+        with open(f"{cwd}/{new}/{rel_path}") as f_new:
+            new_data = json.load(f_new)
+    except FileNotFoundError:
+        failure(f"{rel_path} is present in {baseline}, but not in {new}")
+        
+    with open(path) as f_baseline:
+        baseline_data = json.load(f_baseline)
+
+    check_same_performance_test(new_data, baseline_data, rel_path)
+    compare_measurements(new_data, baseline_data, rel_path)
+
+# Print final conclusion about performance
+if performance_worse:
+    print(f"Conclusion: performance has decreased")
+    exit(EXIT_PERFORMANCE_WORSE)
+elif performance_better:
+    print(f"Conclusion: performance has increased")
+    exit(EXIT_PERFORMANCE_BETTER)
+
+print(f"Conclusion: performance has not significantly changed")
+exit(EXIT_PERFORMANCE_SIMILAR)
+

--- a/test_suite/compare_performance.py
+++ b/test_suite/compare_performance.py
@@ -26,7 +26,7 @@ COMPARISON_CONFIG = {
         "packet_loss": {
             "better": lambda new, baseline: new < 0.9 * baseline,
             # Second condition to prevent performance being considered worse when baseline = 0 and new is very small
-            "worse": lambda new, baseline: new > 1.1 * baseline or (baseline == 0 and new > baseline + 1)
+            "worse": lambda new, baseline: new > 1.1 * baseline or (baseline == 0 and new > baseline + 0.1)
         }
     }
 }

--- a/test_suite/system_tests.sh
+++ b/test_suite/system_tests.sh
@@ -279,7 +279,7 @@ fi
 
 if [[ $performance == true ]]; then
     echo -e "\nPerformance tests (without NAT)"
-    run_system_test -k bitrate -v 100,200,300,400,500 -d 3 -b both TS_PASS_DIRECT router1-router2 : wg0:wg0
+    run_system_test -k bitrate -v 100,200,300,400,500 -d 3 -b both -r 3 TS_PASS_DIRECT router1-router2 : wg0:wg0
 elif [[ -n $file ]]; then
     echo -e "\nTests from file: $file"
     

--- a/test_suite/visualize_performance_tests.py
+++ b/test_suite/visualize_performance_tests.py
@@ -60,18 +60,22 @@ def test_iteration():
             # Delete transform key from bitrate metric, since it is not JSON serializable
             del extracted_data["bitrate"]["transform"]
 
+            # Delete json_key key from all metrics, since they are no longer needed
+            for k in extracted_data.keys():
+                del extracted_data[k]["json_key"]
+
             # Merge test variable info and measurements into one dictionary
             data_dict = {
                 "test_var": test_var_dict,
                 "measurements": extracted_data
             }
 
-            json.dump(data_dict, file)
+            json.dump(data_dict, file, indent=4)
 
         for metric in extracted_data.keys():
-            create_performance_graph(n_tests, test_var, test_var_values, metric, extracted_data, parent_path)
+            create_performance_graph(test_var, test_var_values, metric, extracted_data, parent_path)
 
-        create_variance_grid(n_tests, data_dict, parent_path)
+        create_variance_grid(data_dict, parent_path)
 
     if n_tests > 0:
         plural = "s" if n_tests > 1 else ""
@@ -210,7 +214,7 @@ def axis_label(label_unit_dict: dict) -> str:
     return f"{label_unit_dict["label"]} ({label_unit_dict["unit"]})"
 
 # Graph to illustrate the performance of eduP2P, possibly by comparing against WireGuard and/or a direct connection
-def create_performance_graph(test_idx: int, test_var: str, test_var_values: list[float], metric: str, extracted_data: dict, save_path: str):
+def create_performance_graph(test_var: str, test_var_values: list[float], metric: str, extracted_data: dict, save_path: str):
     metric_data = extracted_data[metric]
     connection_measurements = metric_data["values"]["average"]
     test_var_label = TEST_VARS[test_var]["label"]
@@ -233,11 +237,11 @@ def create_performance_graph(test_idx: int, test_var: str, test_var_values: list
     plt.ticklabel_format(useOffset=False)
     plt.legend()
     plt.tight_layout()
-    plt.savefig(f"{save_path}/performance_test_{test_idx}_{metric}.png")
+    plt.savefig(f"{save_path}/performance_test_{metric}.png")
     plt.clf()
 
 # Create an <n_metrics> * <n_connections> grid of plots showing the variance in measurements across repetitions for each metric and connection type
-def create_variance_grid(test_idx: int, data_dict: dict, save_path: str):
+def create_variance_grid(data_dict: dict, save_path: str):
     test_var_info = data_dict["test_var"]
     test_var_values = test_var_info["values"]
 
@@ -277,7 +281,7 @@ def create_variance_grid(test_idx: int, data_dict: dict, save_path: str):
     fig.set_figheight(n_metrics * subplot_size)
     fig.set_figwidth(n_connections * subplot_size)
     fig.tight_layout()
-    fig.savefig(f"{save_path}/performance_test_{test_idx}_variance.png", bbox_inches="tight") # bbox_inches prevents suptitle and legend from being cropped
+    fig.savefig(f"{save_path}/performance_test_variance.png", bbox_inches="tight") # bbox_inches prevents suptitle and legend from being cropped
 
 # Fill one column of the variance grid with graphs
 def create_variance_col(ax: np.ndarray[plt.Axes], i: int, test_var_values: list[float], measurements: dict):

--- a/test_suite/visualize_performance_tests.py
+++ b/test_suite/visualize_performance_tests.py
@@ -56,7 +56,7 @@ def test_iteration():
         test_var_dict = TEST_VARS[test_var]
         test_var_dict["values"] = test_var_values
 
-        with open(f"{parent_path}/performance_test_{n_tests}_data.json", 'w') as file:
+        with open(f"{parent_path}/performance_test_data.json", 'w') as file:
             # Delete transform key from bitrate metric, since it is not JSON serializable
             del extracted_data["bitrate"]["transform"]
 

--- a/test_suite/visualize_performance_tests.py
+++ b/test_suite/visualize_performance_tests.py
@@ -56,7 +56,7 @@ def test_iteration():
         test_var_dict = TEST_VARS[test_var]
         test_var_dict["values"] = test_var_values
 
-        with open(f"{parent_path}/performance_test_data.json", 'w') as file:
+        with open(f"{parent_path}/performance_test_{n_tests}_data.json", 'w') as file:
             # Delete transform key from bitrate metric, since it is not JSON serializable
             del extracted_data["bitrate"]["transform"]
 
@@ -69,9 +69,9 @@ def test_iteration():
             json.dump(data_dict, file)
 
         for metric in extracted_data.keys():
-            create_performance_graph(test_var, test_var_values, metric, extracted_data, parent_path)
+            create_performance_graph(n_tests, test_var, test_var_values, metric, extracted_data, parent_path)
 
-        create_variance_grid(data_dict, parent_path)
+        create_variance_grid(n_tests, data_dict, parent_path)
 
     if n_tests > 0:
         plural = "s" if n_tests > 1 else ""
@@ -210,7 +210,7 @@ def axis_label(label_unit_dict: dict) -> str:
     return f"{label_unit_dict["label"]} ({label_unit_dict["unit"]})"
 
 # Graph to illustrate the performance of eduP2P, possibly by comparing against WireGuard and/or a direct connection
-def create_performance_graph(test_var: str, test_var_values: list[float], metric: str, extracted_data: dict, save_path: str):
+def create_performance_graph(test_idx: int, test_var: str, test_var_values: list[float], metric: str, extracted_data: dict, save_path: str):
     metric_data = extracted_data[metric]
     connection_measurements = metric_data["values"]["average"]
     test_var_label = TEST_VARS[test_var]["label"]
@@ -233,11 +233,11 @@ def create_performance_graph(test_var: str, test_var_values: list[float], metric
     plt.ticklabel_format(useOffset=False)
     plt.legend()
     plt.tight_layout()
-    plt.savefig(f"{save_path}/performance_test_{metric}.png")
+    plt.savefig(f"{save_path}/performance_test_{test_idx}_{metric}.png")
     plt.clf()
 
 # Create an <n_metrics> * <n_connections> grid of plots showing the variance in measurements across repetitions for each metric and connection type
-def create_variance_grid(data_dict: dict, save_path: str):
+def create_variance_grid(test_idx: int, data_dict: dict, save_path: str):
     test_var_info = data_dict["test_var"]
     test_var_values = test_var_info["values"]
 
@@ -277,7 +277,7 @@ def create_variance_grid(data_dict: dict, save_path: str):
     fig.set_figheight(n_metrics * subplot_size)
     fig.set_figwidth(n_connections * subplot_size)
     fig.tight_layout()
-    fig.savefig(f"{save_path}/performance_test_variance.png", bbox_inches="tight") # bbox_inches prevents suptitle and legend from being cropped
+    fig.savefig(f"{save_path}/performance_test_{test_idx}_variance.png", bbox_inches="tight") # bbox_inches prevents suptitle and legend from being cropped
 
 # Fill one column of the variance grid with graphs
 def create_variance_col(ax: np.ndarray[plt.Axes], i: int, test_var_values: list[float], measurements: dict):


### PR DESCRIPTION
Closes #136 

In the performance tests job of `.github/workflows/CI_test_suite.yml`, the performance of the current run is compared to a previous run:

- If the run was triggered by a push, the performance is compared to the previous commit.
- If the run was triggered by a pull request, the performance is compared to the target branch.

The Python script `test_suite/compare_performance.py` is used to compare the performance of the two runs. This script first makes sure that the two runs contain the same performance test(s), i.e. have the same test values and metrics. Then, it compares the measurements value-by-value to determine if the performance has improved, deteriorated or not changed significantly.

The selection of metrics to be compared can be configured in this Python script. For each metric, it is also possible to configure the range of values relative to the previous performance, in which the new performance will be considered an insignificant change. This prevents any small negative/positive change from being considered a decline/improvement in performance.

The result of the performance comparison is also reflected in the status of the job: the job fails if performance has deteriorated, whereas it succeeds if performance has improved or there were no significant changes. Note that Python script is designed to prioritize performance deteriorations above performance improvements. If there is just one value for which performance has deteriorated, the script will report a decline in performance and hence the workflow will fail, no matter the amount of other values for which performance did improve. The motivation behind this design is to prevent code revisions that accidentally deteriorate performance from going unnoticed. 