### PR TITLE
Parallel system tests

### DIFF
--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Run system tests
       id: system-test
-      run: ./system_tests.sh -c 0
+      run: ./system_tests.sh -b
       working-directory: test_suite
       continue-on-error: true
 
@@ -74,7 +74,7 @@ jobs:
 
     - name: Run performance test with varying bitrate
       id: system-test
-      run: ./system_tests.sh -p -L performance
+      run: ./system_tests.sh -b -p -L performance
       working-directory: test_suite
       continue-on-error: true
 

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Run system tests sequentially
       id: system-test
-      run: ./system_tests.sh
+      run: ./system_tests.sh -b
       working-directory: test_suite
       continue-on-error: true
 

--- a/.github/workflows/CI_test_suite.yml
+++ b/.github/workflows/CI_test_suite.yml
@@ -10,8 +10,9 @@ on:
 
 jobs:
 
-  SystemTests:
+  SystemTestsSequential:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
     - uses: actions/checkout@v4
 
@@ -33,9 +34,44 @@ jobs:
       run: pip install -r python_requirements.txt
       working-directory: test_suite
 
-    - name: Run system tests
+    - name: Run system tests sequentially
       id: system-test
-      run: ./system_tests.sh -b
+      run: ./system_tests.sh
+      working-directory: test_suite
+      continue-on-error: true
+
+    - name: Upload system test logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: system-test-logs
+        path: test_suite/system_test_logs/
+
+    - name: Fail job if system test failed (for clarity in GitHub UI)
+      if: ${{ steps.system-test.outcome == 'failure' }}
+      run: exit 1
+
+  SystemTestsParallel:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Dockerfile to run system tests in parallel
+      uses: docker/build-push-action@v6
+      with:
+        file: test_suite/Dockerfile
+        load: true
+        tags: system_tests:latest
+        build-args: BRANCH=${{ github.ref_name }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Run system tests in parallel
+      id: system-test
+      run: GITHUB_ACTION=true ./system_tests.sh -t 4
       working-directory: test_suite
       continue-on-error: true
 

--- a/test_suite/CHANGELOG.md
+++ b/test_suite/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+In this file, the test suite features that have been made possible thanks to [funding from NLnet](./README.md#funding) are documented. 
+
+
+## Parallel system tests (April 11, 2025)
+
+### Added
+- [Dockerfile](Dockerfile) that installs all requirements to run the test suite's system tests, clones the repository state at the head of a specified branch, and build the eduP2P client, control server and relay server test binaries.
+- Docker Engine as new requirement in [system test requirements](README.md#system-test-specific-requirements).
+- `-t` flag in [system_tests.sh](system_tests.sh) to run the system test in parallel with the specified amount of threads. Each thread is a Docker container in which a portion of the system tests is executed.
+- SystemTestsParallel job in [test suite CI workflow](../.github/workflows/CI_test_suite.yml) that builds the Dockerfile with caching and runs the system tests with the `-t` flag.
+- Explanation of the `-t` flag, motivation for using Docker and reason why parallel system tests currently do not speed up CI runs in the [system test documentation](README.md#system-tests).
+- Log level `trace` (most detailed) in [test_client/main.go](test_client/main.go).
+
+### Changed
+- Building of eduP2P binaries in [system_tests.sh](system_tests.sh) now only happens when explicitly providing the new `-b` flag to save time when the binaries have already been built (e.g. in Dockerfile or on local machine).
+- Optimizations in [test_client/setup_client.sh](test_client/setup_client.sh), such as smaller sleep durations to make the system tests run faster.
+
+### Fixed
+- Bug in [visualize_performance_tests.py](visualize_performance_tests.py): quotation marks inside a format string caused error in some Python versions.
+- Handshake error between eduP2P peers in the system tests caused by both peers initializing a handshake simultaneously. Fixed by desynchronizing the peers with a conditional sleep in [test_client/setup_client.sh](test_client/setup_client.sh). 
+
+## Repeated performance tests (March 7, 2025)
+
+### Added
+- `-r` flag in [performance_tests.sh](performance_tests.sh) to repeat the same performance test multiple times and aggregate the results of each repetition by taking their average.
+- Explanation of the `-r` flag in the [performance test documentation](./README.md#performance-tests).
+- Report on how aggregating the performance test results can improve their reliability in the [performance test results](./README.md#consistency-of-results).
+
+## Simulating network delay (March 4, 2025)
+
+### Added
+- `-d` flag in [system_tests.sh](system_tests.sh) to add artificial network delay in the system tests.
+- New value `delay` for the `-k` flag in [performance_tests.sh](performance_tests.sh) to add variable artificial network delay during the performance tests.
+- Explanation of the delay variable in the [performance test documentation](./README.md#performance-tests).
+- Report on how the delay affects eduP2P network performance in the [performance test results](./README.md#results-with-varying-one-way-delay).

--- a/test_suite/Dockerfile
+++ b/test_suite/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.22
+
+# Add latest repo version to container to prevent Docker from caching the git clone command
+ADD https://api.github.com/repos/eduP2P/common/git/refs/heads/main version.json
+RUN git clone https://github.com/eduP2P/common
+
+WORKDIR /go/common/test_suite
+
+# Commandline dependencies
+RUN apt-get update &&\
+    apt-get -y install sudo &&\
+    xargs -a system_test_requirements.txt sudo apt-get -y install
+
+# Python dependencies
+RUN apt-get -y install python3-pip &&\
+    python3 -m pip config set global.break-system-packages true &&\
+    pip install -r python_requirements.txt
+
+# Build eduP2P binaries
+RUN for binary in test_client control_server relay_server; do go build -o $binary/$binary $binary/*.go; done
+
+# TODO: remove below
+COPY ./system_tests.sh ./system_tests.sh
+COPY ./system_test.sh ./system_test.sh
+COPY ./visualize_performance_tests.py ./visualize_performance_tests.py
+COPY ./test_client/setup_client.sh ./test_client/setup_client.sh
+
+
+ENTRYPOINT ["/go/common/test_suite/system_tests.sh"]

--- a/test_suite/Dockerfile
+++ b/test_suite/Dockerfile
@@ -20,17 +20,13 @@ RUN apt-get update &&\
     apt-get -y install sudo &&\
     xargs -a system_test_requirements.txt sudo apt-get -y install
 
-# Python requirements
-COPY --from=get-requirements /common/test_suite/python_requirements.txt /go/python_requirements.txt
-RUN apt-get -y install python3-pip &&\
-    python3 -m pip config set global.break-system-packages true &&\
-    pip install -r python_requirements.txt
-
 # Go packages
-COPY --from=get-requirements /common/go.mod /go/go.mod
-RUN go mod download
+COPY --from=get-requirements /common/go.mod /go/src/go.mod
+WORKDIR /go/src
+RUN go mod download 
 
 # Clone repository, prevent cache from using old version by adding current version to Dockerfile
+WORKDIR /go
 ADD https://api.github.com/repos/eduP2P/common/git/refs/heads/${BRANCH} version.json
 RUN git clone -b ${BRANCH} --single-branch https://github.com/eduP2P/common
 

--- a/test_suite/Dockerfile
+++ b/test_suite/Dockerfile
@@ -1,29 +1,41 @@
-FROM golang:1.22
+# Git branch
+ARG BRANCH="main"
 
-# Add latest repo version to container to prevent Docker from caching the git clone command
-ADD https://api.github.com/repos/eduP2P/common/git/refs/heads/main version.json
-RUN git clone https://github.com/eduP2P/common
+# Stage that clones repository, to be copied by next stage for cache optimization
+FROM alpine AS get-requirements
+ARG BRANCH
 
-WORKDIR /go/common/test_suite
+# Clone repository, prevent cache from using old version by adding current version to Dockerfile
+RUN apk add --no-cache git 
+ADD https://api.github.com/repos/eduP2P/common/git/refs/heads/${BRANCH} version.json
+RUN git clone -b ${BRANCH} --single-branch https://github.com/eduP2P/common
 
-# Commandline dependencies
+# Stage that makes optimal use of cache by first copying and installing requirements from previous stage, and only cloning repository afterwards
+FROM golang:1.22 AS run-system-tests
+ARG BRANCH
+
+# Command-line requirements
+COPY --from=get-requirements /common/test_suite/system_test_requirements.txt /go/system_test_requirements.txt
 RUN apt-get update &&\
     apt-get -y install sudo &&\
     xargs -a system_test_requirements.txt sudo apt-get -y install
 
-# Python dependencies
+# Python requirements
+COPY --from=get-requirements /common/test_suite/python_requirements.txt /go/python_requirements.txt
 RUN apt-get -y install python3-pip &&\
     python3 -m pip config set global.break-system-packages true &&\
     pip install -r python_requirements.txt
 
+# Go packages
+COPY --from=get-requirements /common/go.mod /go/go.mod
+RUN go mod download
+
+# Clone repository, prevent cache from using old version by adding current version to Dockerfile
+ADD https://api.github.com/repos/eduP2P/common/git/refs/heads/${BRANCH} version.json
+RUN git clone -b ${BRANCH} --single-branch https://github.com/eduP2P/common
+
 # Build eduP2P binaries
+WORKDIR /go/common/test_suite
 RUN for binary in test_client control_server relay_server; do go build -o $binary/$binary $binary/*.go; done
-
-# TODO: remove below
-COPY ./system_tests.sh ./system_tests.sh
-COPY ./system_test.sh ./system_test.sh
-COPY ./visualize_performance_tests.py ./visualize_performance_tests.py
-COPY ./test_client/setup_client.sh ./test_client/setup_client.sh
-
 
 ENTRYPOINT ["/go/common/test_suite/system_tests.sh"]

--- a/test_suite/README.md
+++ b/test_suite/README.md
@@ -63,6 +63,10 @@ sudo and xargs packages):
 
     xargs -a system_test_requirements.txt sudo apt-get install
 
+Optionally, the system tests can be run in parallel. In this mode the
+system tests are distributed over Docker containers, so it requires
+installing [Docker Engine](https://docs.docker.com/engine/install/).
+
 ### Performance test-specific requirements
 
 The performance tests are run as a part of the system tests, and require
@@ -106,6 +110,28 @@ physical setup for two reasons:
     network congestion than a physical network.
 
 The simulated network setup is described in detail in the next section.
+As mentioned in the [system test
+requirements](#system-test-specific-requirements), the tests may be run
+in parallel using Docker. The user can specify the amount of “threads”
+with the `-t` flag, which determines over how many Docker containers the
+tests will be distributed. The reason for using Docker is that it allows
+the concurrent tests to be executed in isolated networks. Naturally,
+running the tests in parallel allows the tests to run much faster. One
+disadvantage of the parallel tests is that a Docker image must be built
+before running the tests. This takes quite a while the first time the
+image is built, but by making use of Docker’s caching, building the
+image again after revisions to the code is significantly faster.
+
+The parallel system tests are also being used in the CI GitHub workflow
+when new code is pushed to a branch. For pull requests, the sequential
+version of the tests is still used because we cannot simply clone the
+branch head inside the Docker image in this case. Currently, running the
+system tests in parallel in CI does not the system test job to run
+faster. The reason for this is that loading and storing the Docker image
+from the GitHub Actions cache takes too long for the speed-up in
+actually running the tests to matter. This problem could potentially be
+solved by deploying a self-hosted runner with persistent memory to
+perform the CI workflow.
 
 ### Network Simulation Setup
 
@@ -562,8 +588,8 @@ establish a connection between peers are well-established
 This test suite uses the RFC 4787 [\[4\]](#ref-rfc4787) terminology,
 which does not categorize NAT into these four types. However, each of
 these four types of NAT described in RFC 3489 uses a different
-combination of the NAT mapping and filtering behaviour described in RFC 4787.
-Below, the four types of NAT from RFC 3489 are listed, while
+combination of the NAT mapping and filtering behaviour described in RFC
+4787. Below, the four types of NAT from RFC 3489 are listed, while
 noting the RFC 4787 mapping and filtering behaviour they are equivalent
 to:
 
@@ -582,12 +608,12 @@ an ‘X’ if UDP hole punching is successful in the scenario where one peer
 is behind the NAT indicated by the cell’s row header, and the other peer
 is behind the NAT indicated by the cell’s column header.
 
-| NAT Type                 | Full Cone | Restricted Cone | Port Restricted Cone | Symmetric |
-|:-------------------------|:----------|:----------------|:---------------------|:----------|
-| **Full Cone**            | X         | X               | X                    | X         |
-| **Restricted Cone**      | X         | X               | X                    | X         |
-| **Port Restricted Cone** | X         | X               | X                    |           |
-| **Symmetric**            | X         | X               |                      |           |
+| NAT Type | Full Cone | Restricted Cone | Port Restricted Cone | Symmetric |
+|:---|:---|:---|:---|:---|
+| **Full Cone** | X | X | X | X |
+| **Restricted Cone** | X | X | X | X |
+| **Port Restricted Cone** | X | X | X |  |
+| **Symmetric** | X | X |  |  |
 
 As seen in the table, UDP hole punching succeeds unless one peer is
 behind a Port Restricted Cone NAT or Symmetric NAT, and the other peer
@@ -696,12 +722,12 @@ of RFC 4787 NAT mapping and filtering behaviour.
 The results of repeating the UDP hole punching experiment with eduP2P
 are shown in the table below:
 
-| NAT Type                 | Full Cone | Restricted Cone | Port Restricted Cone | Symmetric |
-|:-------------------------|:----------|:----------------|:---------------------|:----------|
-| **Full Cone**            | X         | X               | X                    | X         |
-| **Restricted Cone**      | X         | X               | X                    |           |
-| **Port Restricted Cone** | X         | X               | X                    |           |
-| **Symmetric**            | X         |                 |                      |           |
+| NAT Type | Full Cone | Restricted Cone | Port Restricted Cone | Symmetric |
+|:---|:---|:---|:---|:---|
+| **Full Cone** | X | X | X | X |
+| **Restricted Cone** | X | X | X |  |
+| **Port Restricted Cone** | X | X | X |  |
+| **Symmetric** | X |  |  |  |
 
 Comparing this table with the one in the previous section, we see that
 eduP2P is not able to establish a direct connection when one peer is
@@ -994,17 +1020,17 @@ The results of extending the UDP hole punching experiment to all
 combinations of RFC 4787 mapping (EIM, ADM, ADPM) and filtering (EIF,
 ADF, ADPF) behaviours are shown in the table below:
 
-| NAT Type      | EIM-EIF | EIM-ADF | EIM-ADPF | ADM-EIF | ADM-ADF | ADM-ADPF | ADPM-EIF | ADPM-ADF | ADPM-ADPF |
-|:--------------|:--------|:--------|:---------|:--------|:--------|:---------|:---------|:---------|:----------|
-| **EIM-EIF**   | X       | X       | X        | X       | X       | X        | X        | X        | X         |
-| **EIM-ADF**   | X       | X       | X        | X       | X       | X        | X        | X        | X         |
-| **EIM-ADPF**  | X       | X       | X        | X       |         |          | X        |          |           |
-| **ADM-EIF**   | X       | X       | X        | X       | X       | X        | X        | X        | X         |
-| **ADM-ADF**   | X       | X       |          | X       |         |          | X        |          |           |
-| **ADM-ADPF**  | X       | X       |          | X       |         |          | X        |          |           |
-| **ADPM-EIF**  | X       | X       | X        | X       | X       | X        | X        | X        | X         |
-| **ADPM-ADF**  | X       | X       |          | X       |         |          | X        |          |           |
-| **ADPM-ADPF** | X       | X       |          | X       |         |          | X        |          |           |
+| NAT Type | EIM-EIF | EIM-ADF | EIM-ADPF | ADM-EIF | ADM-ADF | ADM-ADPF | ADPM-EIF | ADPM-ADF | ADPM-ADPF |
+|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
+| **EIM-EIF** | X | X | X | X | X | X | X | X | X |
+| **EIM-ADF** | X | X | X | X | X | X | X | X | X |
+| **EIM-ADPF** | X | X | X | X |  |  | X |  |  |
+| **ADM-EIF** | X | X | X | X | X | X | X | X | X |
+| **ADM-ADF** | X | X |  | X |  |  | X |  |  |
+| **ADM-ADPF** | X | X |  | X |  |  | X |  |  |
+| **ADPM-EIF** | X | X | X | X | X | X | X | X | X |
+| **ADPM-ADF** | X | X |  | X |  |  | X |  |  |
+| **ADPM-ADPF** | X | X |  | X |  |  | X |  |  |
 
 Based on these results, we can conclude that there are three
 (overlapping) types of NAT scenarios where the UDP hole punching process
@@ -1390,8 +1416,8 @@ Network Emulator</span>.” Available:
 </span><span class="csl-right-inline">J. Rosenberg, C. Huitema, R. Mahy,
 and J. Weinberger, “<span class="nocase">STUN - Simple Traversal of User
 Datagram Protocol (UDP) Through Network Address Translators
-(NATs)</span>.” in Request for comments. RFC 3489; RFC Editor, Mar. 2003. 
-doi: [10.17487/RFC3489](https://doi.org/10.17487/RFC3489).</span>
+(NATs)</span>.” in Request for comments. RFC 3489; RFC Editor, Mar.
+2003. doi: [10.17487/RFC3489](https://doi.org/10.17487/RFC3489).</span>
 
 </div>
 
@@ -1428,33 +1454,3 @@ Conservancy](https://commonsconservancy.org/).
 
 The test suite features that have been made possible thanks to this
 funding are described below.
-
-### Simulating network delay (finished March 4, 2025)
-
-This feature makes it possible to add artificial network delay in the
-system and performance tests.
-
-The feature can be used with the system tests by calling
-`system_tests.sh` with the option `-d <delay in ms>`. In the performance
-tests, this artificial delay can be configured as the independent test
-variable. More details are given in the [performance test
-documentation](./README.md#performance-tests).
-
-Furthermore, the effect of the artificial delay on the eduP2P network
-performance is reported in the [performance test
-results](./README.md#results-with-varying-one-way-delay).
-
-### Repeated performance tests (finished March 7, 2025)
-
-This feature adds the option to repeat the same performance test
-multiple times and aggregate the results of each repetition by taking
-their average.
-
-The option is configured with the `-r` flag of the performance tests.
-See the [performance test documentation](./README.md#performance-tests)
-for details on how to configure and run a performance test.
-
-In the [performance test results](./README.md#consistency-of-results),
-the variance between different repetitions of the same performance test
-is analysed. This analysis shows that aggregating the results can
-improve their reliability.

--- a/test_suite/system_test.sh
+++ b/test_suite/system_test.sh
@@ -37,7 +37,7 @@ If [WIREGUARD INTERFACE 1] or [WIREGUARD INTERFACE 2] is not provided, the corre
 
 <IP ADDRESS LIST> is a string of IP addresses separated by a space that may be the destination IP of packets crossing this NAT device, and is necessary to simulate an Address-Dependent Mapping
 
-<LOG LEVEL> should be one of {debug|info|warn|error}, and MUST be debug if one of the peers uses userspace WireGuard (the other peer's IP address is not logged otherwise)"""
+<LOG LEVEL> should be one of {trace|debug|info|warn|error}, and MUST be trace/debug if one of the peers uses userspace WireGuard (the other peer's IP address is not logged otherwise)"""
 
 # Use functions and constants from util.sh
 . ./util.sh

--- a/test_suite/system_test.sh
+++ b/test_suite/system_test.sh
@@ -37,7 +37,7 @@ If [WIREGUARD INTERFACE 1] or [WIREGUARD INTERFACE 2] is not provided, the corre
 
 <IP ADDRESS LIST> is a string of IP addresses separated by a space that may be the destination IP of packets crossing this NAT device, and is necessary to simulate an Address-Dependent Mapping
 
-<LOG LEVEL> should be one of {trace|debug|info} (in order of most to least log messages), but can NOT be info if one if the peers is using userspace WireGuard (then IP of the other peer is not logged)"""
+<LOG LEVEL> should be one of {debug|info|warn|error}, and MUST be debug if one of the peers uses userspace WireGuard (the other peer's IP address is not logged otherwise)"""
 
 # Use functions and constants from util.sh
 . ./util.sh

--- a/test_suite/system_test.sh
+++ b/test_suite/system_test.sh
@@ -274,7 +274,7 @@ done
 for i in {0..1}; do 
     peer_id="peer$((i+1))"
     export LOG_FILE=${log_dir}/$peer_id.txt # Export to use in bash -c
-    timeout ${SYSTEM_TEST_TIMEOUT}s bash -c 'tail -n +1 -f $LOG_FILE | sed -n "/TS_PASS/q2; /TS_FAIL/q3"' # bash -c is necessary to use timeout with | and still get the right exit codes
+    timeout ${SYSTEM_TEST_TIMEOUT}s bash -c 'tail -f -n +1 -s0.1 $LOG_FILE | sed -n "/TS_PASS/q2; /TS_FAIL/q3"' # bash -c is necessary to use timeout with | and still get the right exit codes
 
     # Branch on exit code of previous command
     case $? in

--- a/test_suite/system_test.sh
+++ b/test_suite/system_test.sh
@@ -162,6 +162,11 @@ wg_interface_regex="^([^:]*):([^:]*)$"
 validate_str $wg_interface_str $wg_interface_regex 
 wg_interfaces=(${BASH_REMATCH[1]} ${BASH_REMATCH[2]})
 
+# Remove conntrack entries from potential previous tests
+for router_ns in ${router_ns_list[@]}; do
+    sudo ip netns exec $router_ns conntrack -D &> /dev/null
+done
+
 # Prepare a string describing the NAT setup
 NAT_TYPES=("EI" "AD" "APD")
 

--- a/test_suite/system_test.sh
+++ b/test_suite/system_test.sh
@@ -239,6 +239,9 @@ function clean_exit() {
     # Kill background processes, such as the setup_client.sh scripts
     sudo kill $(jobs -p) &> /dev/null
 
+    # Remove restrictive permissions on certain log files
+    sudo chmod --recursive 777 $log_dir
+
     exit $exit_code
 }
 
@@ -271,7 +274,7 @@ for i in {0..1}; do
     
     touch $peer_logfile # Make sure file already exists so tail command later in script does not fail
     sudo ip netns exec $peer_ns ./setup_client.sh `# Run script in peer's network namespace` \
-    $peer_id $peer_ns $test_target $control_pub_key $control_ip $control_port $log_lvl ${wg_interfaces[$i]} `# Positional parameters` \
+    $peer_id $peer_ns $test_target $control_pub_key $control_ip $control_port $log_lvl $log_dir ${wg_interfaces[$i]} `# Positional parameters` \
     2>&1 | tee $peer_logfile &> /dev/null & # Combination of tee and redirect to /dev/null is necessary to avoid weird behaviour caused by redirecting a script run with sudo
 done
 

--- a/test_suite/system_tests.sh
+++ b/test_suite/system_tests.sh
@@ -22,12 +22,13 @@ The following options can be used to configure additional parameters during the 
     -d <delay>
         Add delay to packets transmitted by the eduP2P clients, control server and relay server
         The delay should be provided as an integer that represents the one-way delay in milliseconds
-    -l <debug|info|warn|error>
+    -l <trace|debug|info|warn|error>
         Specifies the log level used in the eduP2P client of the two peers
-        If one of the peers uses userspace WireGuard, the log level debug must be used, since the other peer's IP address is not logged otherwise
+        If one of the peers uses userspace WireGuard, the log level trace/debug must be used, since the other peer's IP address is not logged otherwise
     -L <log directory>
         Specifies the alphanumeric name of the directory inside system_test_logs/ where the test logs will be stored
         If this argument is not provided, the directory name is the current timestamp"""
+
 # Use functions and constants from util.sh
 . ./util.sh
 
@@ -73,7 +74,7 @@ while getopts ":c:d:ef:l:L:ph" opt; do
         l)  
             log_lvl=$OPTARG
 
-            log_lvl_regex="^debug|info|warn|error?$"
+            log_lvl_regex="^trace|debug|info|warn|error?$"
             validate_str $log_lvl $log_lvl_regex
             ;;
         L)

--- a/test_suite/system_tests.sh
+++ b/test_suite/system_tests.sh
@@ -145,7 +145,7 @@ function build_go() {
     done
 }
 
-if [[ $performance == true ]]; then
+if [[ $build == true ]]; then
     echo "Building binaries..."
     build_go
 else

--- a/test_suite/system_tests.sh
+++ b/test_suite/system_tests.sh
@@ -22,9 +22,9 @@ The following options can be used to configure additional parameters during the 
     -d <delay>
         Add delay to packets transmitted by the eduP2P clients, control server and relay server
         The delay should be provided as an integer that represents the one-way delay in milliseconds
-    -l <info|debug|trace>
+    -l <debug|info|warn|error>
         Specifies the log level used in the eduP2P client of the two peers
-        The log level 'info' should not be used if a system test is run where one of the peers uses userspace WireGuard (the other peer's IP address is not logged in this case)
+        If one of the peers uses userspace WireGuard, the log level debug must be used, since the other peer's IP address is not logged otherwise
     -L <log directory>
         Specifies the alphanumeric name of the directory inside system_test_logs/ where the test logs will be stored
         If this argument is not provided, the directory name is the current timestamp"""
@@ -73,8 +73,7 @@ while getopts ":c:d:ef:l:L:ph" opt; do
         l)  
             log_lvl=$OPTARG
 
-            # Log level should be info/debug/trace
-            log_lvl_regex="^info|debug|trace?$"
+            log_lvl_regex="^debug|info|warn|error?$"
             validate_str $log_lvl $log_lvl_regex
             ;;
         L)

--- a/test_suite/system_tests.sh
+++ b/test_suite/system_tests.sh
@@ -29,7 +29,8 @@ The following options can be used to configure additional parameters during the 
         Specifies the alphanumeric name of the directory inside system_test_logs/ where the test logs will be stored
         If this argument is not provided, the directory name is the current timestamp
     -t <number of threads between 2 and 8>
-        Run the system tests in parallel with the specified number of threads.
+        Run the system tests in parallel with the specified number of threads. 
+        It is not recommended to combine this flag with -p, as multithreading will likely degrade the performance and the graphs will not be created automatically
     -b
         Build the client, control server and relay server binaries before running the tests"""
 
@@ -456,20 +457,34 @@ if [[ -n $n_threads ]]; then
                                            $system_test_opts) # Copy the remaining options from the current system tests command
         container_ids+=($container_id)
 
-        # Print progress bar for this thread
-        echo -e "\tThread $i: $(progress_bar 0 ${assigned[$((i-1))]})\r"
+        # Print progress bar for this thread, unless test is run as GitHub Action
+        if [[ -z $GITHUB_ACTION ]]; then
+            echo -e "\tThread $i: $(progress_bar 0 ${assigned[$((i-1))]})\r"
+        fi
     done
 
-    monitor_thread_progress &
-    progress_pid=$!
+    # Report on progress of each thread
+    if [[ -z $GITHUB_ACTION ]]; then
+        monitor_thread_progress &
+        progress_pid=$!
+    fi
 
     exit_codes=( $(docker wait ${container_ids[@]}) ) # Each exit code represents the amount of failed tests in the corresponding container
 
-    kill $progress_pid # Stop monitoring progress after all containers have finished
+    if [[ -z $GITHUB_ACTION ]]; then
+        kill $progress_pid # Stop monitoring progress after all containers have finished
+    fi
 
     # Print summary for each thread individually
     for i in $(seq 0 $((n_threads-1))); do
-        log_parallel $i "$(progress_bar ${assigned[$i]} ${assigned[$i]}) - $(print_summary ${exit_codes[$i]} ${assigned[$i]})"
+        test_summary=$(print_summary ${exit_codes[$i]} ${assigned[$i]})
+
+        if [[ -z $GITHUB_ACTION ]]; then
+            progress_bar=$(progress_bar ${assigned[$i]} ${assigned[$i]})
+            log_parallel $i "$progress_bar - $test_summary"
+        else
+            echo -e "\tThread $((i+1)): $test_summary"
+        fi
     done
 
     # Replace space delimiters by + and pipe into calculator

--- a/test_suite/test_client/main.go
+++ b/test_suite/test_client/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/edup2p/common/extwg"
 	"github.com/edup2p/common/toversok"
+	"github.com/edup2p/common/types"
 	"github.com/edup2p/common/types/dial"
 	"github.com/edup2p/common/types/key"
 	"github.com/edup2p/common/usrwg"
@@ -76,6 +77,8 @@ func main() {
 	level := slog.LevelInfo
 
 	switch logLevel {
+	case "trace":
+		level = types.LevelTrace
 	case "debug":
 		level = slog.LevelDebug
 	case "info":

--- a/test_suite/test_client/setup_client.sh
+++ b/test_suite/test_client/setup_client.sh
@@ -52,6 +52,7 @@ fi
 
 # Create temporary file to store test_client output
 out="test_client_out_${id}.txt"
+touch $out
 
 # Run test_client and store its output in the temporary file
 (sudo ./test_client --control-host=$control_ip --control-port=$control_port --control-key=control:$control_pub_key --ext-wg-device=$wg_interface --log-level=$log_lvl --config=$id.json 2>&1 | tee $out &)
@@ -147,6 +148,9 @@ else
     peer_ipv4=$(echo $peer_ips | cut -d ' ' -f1)
     peer_ipv6=$(echo $peer_ips | cut -d ' ' -f2)
 fi
+
+# Necessary to avoid failures with hairpinning tests, probably caused by delay in adding nftables rules to simulate hairpinning
+sleep 0.5s
 
 # Start HTTP servers on own virtual IPs for peer to access, and save their pids to kill them during cleanup
 http_ipv4_out="http_ipv4_output_${id}.txt"

--- a/test_suite/test_client/setup_client.sh
+++ b/test_suite/test_client/setup_client.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 usage_str="""
-Usage: ${0} <PEER ID> <PEER NAMESPACE> <TEST TARGET> <CONTROL SERVER PUBLIC KEY> <CONTROL SERVER IP> <CONTROL SERVER PORT> <LOG LEVEL> [WIREGUARD INTERFACE]
+Usage: ${0} <PEER ID> <PEER NAMESPACE> <TEST TARGET> <CONTROL SERVER PUBLIC KEY> <CONTROL SERVER IP> <CONTROL SERVER PORT> <LOG LEVEL> <LOG DIRECTORY> [WIREGUARD INTERFACE]
 
 <LOG LEVEL> should be one of {trace|debug|info} (in order of most to least log messages), but can NOT be info if one if the peers is using userspace WireGuard (then IP of the other peer is not logged)
 
@@ -27,8 +27,8 @@ done
 shift $((OPTIND-1))
 
 # Make sure all required positional parameters have been passed
-min_req=7
-max_req=8
+min_req=8
+max_req=9
 
 if [[ $# < $min_req || $# > $max_req ]]; then
     exit_with_error "expected $min_req or $max_req positional parameters, but received $#"
@@ -41,7 +41,8 @@ control_pub_key=$4
 control_ip=$5
 control_port=$6
 log_lvl=$7
-wg_interface=$8
+log_dir=$8
+wg_interface=$9
 
 # Create WireGuard interface if wg_interface is set
 if [[ -n $wg_interface ]]; then
@@ -62,9 +63,6 @@ function clean_exit() {
 
     # Remove temporary test_client output file
     sudo rm $out
-
-    # Remove http server output file if it exists
-    rm $http_ipv6_out &> /dev/null
 
     # Kill http servers if they are running
     kill $http_ipv4_pid &> /dev/null
@@ -153,10 +151,11 @@ fi
 sleep 0.5s
 
 # Start HTTP servers on own virtual IPs for peer to access, and save their pids to kill them during cleanup
-python3 -m http.server -b $ipv4 80 &> /dev/null &
+http_ipv4_out="$log_dir/${id}_http_ipv4.txt"
+python3 -m http.server -b $ipv4 80 &> $http_ipv4_out &
 http_ipv4_pid=$!
 
-http_ipv6_out="http_ipv6_output_${id}.txt"
+http_ipv6_out="$log_dir/${id}_http_ipv6.txt"
 python3 -m http.server -b $ipv6 80 &> $http_ipv6_out &
 http_ipv6_pid=$!
 

--- a/test_suite/test_client/setup_client.sh
+++ b/test_suite/test_client/setup_client.sh
@@ -153,7 +153,6 @@ fi
 sleep 0.5s
 
 # Start HTTP servers on own virtual IPs for peer to access, and save their pids to kill them during cleanup
-http_ipv4_out="http_ipv4_output_${id}.txt"
 python3 -m http.server -b $ipv4 80 &> /dev/null &
 http_ipv4_pid=$!
 

--- a/test_suite/visualize_performance_tests.py
+++ b/test_suite/visualize_performance_tests.py
@@ -207,7 +207,7 @@ def aggregate_repetitions(extracted_data: dict) -> dict:
 
 # Given a dictionary containing the label and unit of a metric, returns a string to describe the metric on a graph axis
 def axis_label(label_unit_dict: dict) -> str:
-    return f"{label_unit_dict["label"]} ({label_unit_dict["unit"]})"
+    return f"{label_unit_dict['label']} ({label_unit_dict['unit']})"
 
 # Graph to illustrate the performance of eduP2P, possibly by comparing against WireGuard and/or a direct connection
 def create_performance_graph(test_var: str, test_var_values: list[float], metric: str, extracted_data: dict, save_path: str):


### PR DESCRIPTION
Closes #90 

The most significant changes in this pull request are described in the new CHANGELOG.md file added by this pull request. The last two commits of this pull request concern the review comments on the file `test_suite/test_client/setup_client.sh` (see below).

One interesting result is that the parallel system tests do not cause the system test job of the CI test suite to run faster, because the time spent building a Docker image, or loading and storing it via GitHub Actions cache, negates any speed-up in actually running the performance tests. Deploying a self-hosted runner to perform the CI test suite jobs could solve this issue, as described in #147 .